### PR TITLE
Don't directly touch AR::Base, but do it via AS.on_load

### DIFF
--- a/lib/activerecord-mysql-index-hint.rb
+++ b/lib/activerecord-mysql-index-hint.rb
@@ -1,5 +1,4 @@
 require 'active_record'
-require 'active_record/relation/query_methods'
 
 module ActiveRecordMysqlIndexHint
   def use_index(*args)
@@ -22,5 +21,8 @@ module ActiveRecordMysqlIndexHint
   end
 end
 
-ActiveRecord::Base.extend ActiveRecordMysqlIndexHint
-ActiveRecord::Relation.send :include, ActiveRecordMysqlIndexHint
+ActiveSupport.on_load :active_record do
+  require 'active_record/relation/query_methods'
+  ActiveRecord::Base.extend ActiveRecordMysqlIndexHint
+  ActiveRecord::Relation.send :include, ActiveRecordMysqlIndexHint
+end


### PR DESCRIPTION
Otherwise, requiring this gem (usually via Bundler) will immediately load AR::Base and trigger all of its initializers, which would slowdown the server startup, spec execution that does not depend on AR, etc.
