### PR TITLE
Patches for Rails 5

### DIFF
--- a/lib/activerecord-mysql-index-hint.rb
+++ b/lib/activerecord-mysql-index-hint.rb
@@ -22,7 +22,6 @@ module ActiveRecordMysqlIndexHint
 end
 
 ActiveSupport.on_load :active_record do
-  require 'active_record/relation/query_methods'
   ActiveRecord::Base.extend ActiveRecordMysqlIndexHint
   ActiveRecord::Relation.send :include, ActiveRecordMysqlIndexHint
 end

--- a/spec/activerecord-mysql-index-hint_spec.rb
+++ b/spec/activerecord-mysql-index-hint_spec.rb
@@ -23,6 +23,10 @@ module ActiveRecord
 
         def configure_connection
         end
+
+        def full_version
+          "5.0.0"
+        end
       }
     end
   end


### PR DESCRIPTION
These are patches to support Rails5.
- Remove unnecessary requirement
  In Rails5 active_record/relation/query_methods must be loaded after active_record/relation, so that
  `require 'activerecord-mysql-index-hint'` raises `NameError`.
  https://travis-ci.org/mirakui/activerecord-mysql-index-hint/jobs/116399791

On the other hand, `require 'active_record/relation/query_methods'` seems to not be necessary because 
`require 'active_record` sets `autoload` for `AcitveRecord::Relation::QueryMethods`.
- Fake MySQL version
  Rails5 support MySQL >= 5.0
  https://github.com/rails/rails/commit/c7f8019bff16554095ff5c2c4e539962922b7a55
